### PR TITLE
Support Workspace Trust

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
                     "highContrast": "#4169E1"
                 }
             }
-        ]
+        ],
+        "untrustedWorkspaces": {
+            "supported": true
+        }
     },
     "scripts": {
         "vscode:prepublish": "webpack --mode production",


### PR DESCRIPTION
Hi the VSCode team has just enabled Workspace Trust by default on Insiders. More info here: https://github.com/microsoft/vscode/issues/120251.

This PR enables support, allowing this extension to work in untrusted workspaces.