### PR TITLE
feat: `matchAlgorithm` option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,10 +13,8 @@
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ],
-            "outFiles": [
-                "${workspaceFolder}/out/**/*.js"
-            ],
-            "preLaunchTask": "npm: webpack"
+            "preLaunchTask": "npm: webpack",
+            "sourceMaps": true
         },
         {
             "name": "Extension Tests",

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Bind the following keyboard shortcuts and you'll be ready to start using the ext
 
 > ℹ️ No default keybindings are provided by this extension - you'll have to bind the commands yourself.
 
+- `findThenJump.matchAlgorithm`: Specify the algorithm used for matching text for navigation.
+
+Available options are:
+
+- `default`: Matches any text. (default)
+- `word-start`: Matches the start of alphanumerical or special character sequences separated by whitespace.
+- `alpha-start`: Matches the start of alphanumerical-only character sequences separated by whitespace.
+
 ## Theming
 
 You can customize the colors of the text decorations that are displayed left of each text match by adding the following settings to `settings.json`:

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
-        "webpack": "webpack --mode development",
-        "webpack-dev": "webpack --mode development --watch",
+        "webpack": "NODE_OPTIONS=--openssl-legacy-provider webpack --mode development",
+        "webpack-dev": "NODE_OPTIONS=--openssl-legacy-provider webpack --mode development --watch",
         "test": "npm run compile && node ./node_modules/vscode/bin/test",
         "test-compile": "tsc -p ./"
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "url": "https://github.com/tranhl/find-then-jump.git"
     },
     "activationEvents": [
-        "*"
+        "onCommand:findThenJump.initiate",
+        "onCommand:findThenJump.initiateWithSelection"
     ],
     "main": "./dist/extension.js",
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -55,10 +55,15 @@
             {
                 "title": "findThenJump configurations",
                 "properties": {
-                    "findThenJump.findOnlyStartOfWords": {
-                        "type": "boolean",
-                        "description": "Use word start regex instead of finding characters inside words.",
-                        "default": false
+                    "findThenJump.matchAlgorithm": {
+                        "type": "string",
+                        "description": "Algorithm to use for matching. Can be 'default', 'word-start' or 'alpha-start'.",
+                        "default": "default",
+                        "enum": [
+                            "default",
+                            "word-start",
+                            "alpha-start"
+                        ]
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,18 @@
                 }
             }
         ],
+        "configuration": [
+            {
+                "title": "findThenJump configurations",
+                "properties": {
+                    "findThenJump.findOnlyStartOfWords": {
+                        "type": "boolean",
+                        "description": "Use word start regex instead of finding characters inside words.",
+                        "default": true
+                    }
+                }
+            }
+        ],
         "untrustedWorkspaces": {
             "supported": true
         }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
                     "findThenJump.findOnlyStartOfWords": {
                         "type": "boolean",
                         "description": "Use word start regex instead of finding characters inside words.",
-                        "default": true
+                        "default": false
                     }
                 }
             }

--- a/src/associationManager.ts
+++ b/src/associationManager.ts
@@ -3,7 +3,7 @@ import {
   TextEditor,
 } from 'vscode'
 
-import {Association} from './Association'
+import {Association} from './association'
 import {Match} from './documentScanner'
 
 export class AssociationManager {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,7 +1,7 @@
 import { workspace, WorkspaceConfiguration } from "vscode"
 
 export interface ExtensionConfiguration extends WorkspaceConfiguration {
-  findOnlyStartOfWords: boolean
+  matchAlgorithm: 'default' | 'word-start' | 'alpha-start'
 }
 
 let cfg = workspace.getConfiguration('findThenJump') as ExtensionConfiguration

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,14 @@
+import { workspace, WorkspaceConfiguration } from "vscode"
+
+export interface ExtensionConfiguration extends WorkspaceConfiguration {
+  findOnlyStartOfWords: boolean
+}
+
+let cfg = workspace.getConfiguration('findThenJump') as ExtensionConfiguration
+workspace.onDidChangeConfiguration((event) => {
+  if (event.affectsConfiguration('findThenJump')) {
+    cfg = workspace.getConfiguration('findThenJump') as ExtensionConfiguration
+  }
+})
+
+export const getConfiguration = () => cfg

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -79,10 +79,9 @@ class Controller {
 
   private updateJumpOptions = (input: string) => {
     this.setupDocumentScanner(input)
+    if (this.inputMatches.length >= this.availableJumpChars.length) return
 
     for (const match of this.documentScanner) {
-      if (this.inputMatches.length >= this.availableJumpChars.length) return
-
       this.removeExcludedCharsFromAvailableChars(match.excludedChars)
       this.inputMatches.push(match)
     }

--- a/src/documentScanner.ts
+++ b/src/documentScanner.ts
@@ -32,8 +32,8 @@ class DocumentScanner implements IterableIterator<any> {
   static EXCLUSION_LOOKAHEAD_LENGTH: number = 8
   static ITERATION_LIMIT: number = 200
   static NON_ALPHABETS: RegExp = /[^a-z]/gi
-  static ALPHA_START: RegExp = /^(([a-z]|[A-Z])?[^a-zA-Z]|[a-z][A-Z])/g
-  static WORD_START: RegExp = /^([^a-zA-Z]|[a-z][A-Z])/g
+  static ALPHA_START: RegExp = /^([^a-zA-Z]|[a-z][A-Z])/g
+  static WORD_START: RegExp = /^(([a-z]|[A-Z])?[^a-zA-Z]|[a-z][A-Z])/g
 
   readonly document: TextDocument
   scannerState: ScannerState

--- a/src/documentScanner.ts
+++ b/src/documentScanner.ts
@@ -49,7 +49,7 @@ class DocumentScanner implements IterableIterator<any> {
     }
 
     // We want jump option updates to be as responsive as possible while the
-    // user is typing, so we optimise this by generating the order of lines that
+    // user is typing, so we optimize this by generating the order of lines that
     // the scanner will go through while the extension is loading (it loads
     // every time the keyboard shortcut is activated). This greatly simplifies
     // the matching algorithm while the user is typing.
@@ -124,7 +124,7 @@ class DocumentScanner implements IterableIterator<any> {
 
       // It's common to have many matches for any given search term (needle) on
       // any line of text. String.prototype.indexOf() only returns the index of 
-      // the *fist* match, so we need to keep track of this and continue the
+      // the *first* match, so we need to keep track of this and continue the
       // search until we reach the end of the line.
       for (let needleSearchResumePosition = 0;;) {
         needleSearchResumePosition = haystack.indexOf(needle, needleSearchResumePosition)
@@ -147,10 +147,9 @@ class DocumentScanner implements IterableIterator<any> {
 
   private getExcludedChars = (haystack: string, matchEndIndex: number) => {
     const haystackExclusionEndIndex = matchEndIndex + DocumentScanner.EXCLUSION_LOOKAHEAD_LENGTH
-    const unfilteredExcludedChars = haystack.slice(matchEndIndex, haystackExclusionEndIndex)
-    const filteredExcludedChars = unfilteredExcludedChars.replace(DocumentScanner.NON_ALPHABETS, '')
+    const unfilteredExcludedChars = haystack.slice(matchEndIndex, haystackExclusionEndIndex).split(DocumentScanner.NON_ALPHABETS)[0]
 
-    return [...filteredExcludedChars]
+    return [...unfilteredExcludedChars]
   }
 
   private createMatch = (

--- a/src/documentScanner.ts
+++ b/src/documentScanner.ts
@@ -148,10 +148,11 @@ class DocumentScanner implements IterableIterator<any> {
         const noMatchFound = needleSearchResumePosition === -1
         if (noMatchFound) break
 
-        if (matchRegex != null) {
+        if (matchRegex != null && needleSearchResumePosition > 0) {
           // Further filter out the 'inside a word' matches
-          const substr = line.slice(Math.max(needleSearchResumePosition - 1, 0), needleSearchResumePosition + needle.length)
-          if (!substr.match(matchRegex)) {
+          const substr = line.slice(needleSearchResumePosition - 1, needleSearchResumePosition + needle.length)
+          const isWordStartLike = substr.match(matchRegex)
+          if (!isWordStartLike) {
             needleSearchResumePosition += needle.length
             continue
           }

--- a/src/documentScanner.ts
+++ b/src/documentScanner.ts
@@ -173,9 +173,10 @@ class DocumentScanner implements IterableIterator<any> {
 
   private getExcludedChars = (haystack: string, matchEndIndex: number) => {
     const haystackExclusionEndIndex = matchEndIndex + DocumentScanner.EXCLUSION_LOOKAHEAD_LENGTH
-    const unfilteredExcludedChars = haystack.slice(matchEndIndex, haystackExclusionEndIndex).split(DocumentScanner.NON_ALPHABETS)[0]
+    const unfilteredExcludedChars = haystack.slice(matchEndIndex, haystackExclusionEndIndex)
+    const filteredExcludedChars = unfilteredExcludedChars.replace(DocumentScanner.NON_ALPHABETS, '')
 
-    return [...unfilteredExcludedChars]
+    return [...filteredExcludedChars]
   }
 
   private createMatch = (

--- a/src/documentScanner.ts
+++ b/src/documentScanner.ts
@@ -32,7 +32,7 @@ class DocumentScanner implements IterableIterator<any> {
   static EXCLUSION_LOOKAHEAD_LENGTH: number = 8
   static ITERATION_LIMIT: number = 200
   static NON_ALPHABETS: RegExp = /[^a-z]/gi
-  static WORD_START: RegExp = /^([^a-zA-Z]|[a-z][A-Z])/g
+  static WORD_START: RegExp = /^(([a-z]|[A-Z])?[^a-zA-Z]|[a-z][A-Z])/g
 
   readonly document: TextDocument
   scannerState: ScannerState

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "strict": true,
     "module": "commonjs",
     "target": "es6",
-    "outDir": "out",
+    "outDir": "dist",
     "lib": [
       "es6"
     ],


### PR DESCRIPTION
# What
- Minor bugfixes to reduce the occurrences of finding matches only near the cursor
- Add an option to search matches only from the start of the word instead of wherever

# Why
I'v been enjoying this extension but there has been times when it drives me crazy when it only shows match options near the cursor and I need to use old-fashioned-super-slow-navigation. I was about to add support for multichar navigation (for myself mostly because I saw the open issue about it https://github.com/tranhl/find-then-jump/issues/53) to overcome that but when implementing it I stumbled couple of minor bugs. After fixing those little bugs I realized that those were the ones causing my problem at the first place and there's no need for multichar navigation support at all.